### PR TITLE
missed env var call

### DIFF
--- a/gitlab-lib.yaml
+++ b/gitlab-lib.yaml
@@ -10,7 +10,7 @@
     - |
       set -e
       mkdir -p /etc/gitlab-runner/certs/
-      [ "x$CONTAINERS_FILE" != "x" ] && export CONTAINERS="$(cat CONTAINERS_FILE)"
+      [ "x$CONTAINERS_FILE" != "x" ] && export CONTAINERS="$(cat $CONTAINERS_FILE)"
       echo "Mirroring: $CONTAINERS"
       echo "$CONTAINERS" | while read IMAGE; do
         [ "x$IMAGE" == "x" ] && continue


### PR DESCRIPTION
Trying to fix
```
$ set -e # collapsed multi-line command
cat: CONTAINERS_FILE: No such file or directory
```