### PR TITLE
Adding flag to force refresh during mirror-container-images job

### DIFF
--- a/gitlab-lib.yaml
+++ b/gitlab-lib.yaml
@@ -4,6 +4,7 @@
     # CONTAINERS_FILE - Optional artifact filename which lists the desired images to be cached in a multiline format
     # CONTAINER_CONVERT - define if the images must be converted to store in gitlab
     # CONTAINER_PREFIX - extra prefix for the images. Can be used to add a string on the front of an image name or a parent directory in the repository.
+    # FORCE_REFRESH - Optional flag to indicate that the mirrored container should be pulled even if the tag is already seen.
     # RETAG - Change the tag or sha of the image. to rename the image from foo:bar to foo:baz, set to "\1:baz"
     # SOURCE_USERNAME - Optional username to use for download
     # SOURCE_PASSWORD - Optional password to use for download
@@ -31,14 +32,16 @@
         mkdir -p /tmp/containers/"$NEWNAME"
         echo Mirroring "$IMAGE" to "$NEWNAME"
         if [ "x$CONTAINER_CONVERT" != "x" ]; then
-          set +e
-          skopeo inspect \
-            docker://"${DEST_REGISTRY}/${DEST_REGISTRY_PATH}/${CONTAINER_PREFIX}$NEWNAME" \
-            --raw \
-            --cert-dir /etc/gitlab-runner/certs/ \
-            --creds "${DEST_REGISTRY_USERNAME}:${DEST_REGISTRY_PASSWORD}" \
-            > /dev/null && echo already exists && continue
-          set -xe
+          if [ "x$FORCE_REFRESH" == "x"]; then 
+            set +e
+            skopeo inspect \
+              docker://"${DEST_REGISTRY}/${DEST_REGISTRY_PATH}/${CONTAINER_PREFIX}$NEWNAME" \
+              --raw \
+              --cert-dir /etc/gitlab-runner/certs/ \
+              --creds "${DEST_REGISTRY_USERNAME}:${DEST_REGISTRY_PASSWORD}" \
+              > /dev/null && echo already exists && continue
+            set -xe
+          fi
           skopeo copy $EXTRA_FLAGS \
             --format v2s2 \
             docker://"$IMAGE" \


### PR DESCRIPTION
Looking at the usage in lims/infrastructure/base-images, I believe I set up my updates on line 35 correctly, but my gitlab/shell-fu is not super strong.
The intent is that if the new flag "FORCE_REFRESH" is not present, no differences will occur and the pull of the image will not happen if the image is already seen in the registry. Otherwise, it would update the image in the registry for the requested tag.